### PR TITLE
Fix include/lib issues, add tests, & clang version

### DIFF
--- a/iwyu.rb
+++ b/iwyu.rb
@@ -39,9 +39,10 @@ class Iwyu < Formula
     iwyu_subdir_path = (prefix / "iwyu")
     iwyu_subdir_path.mkpath
 
-    xcode_maj_min_version = MacOS::Xcode.version[/\A\d+\.\d+/, 0]
-    clang_libs = "#{MacOS::Xcode.toolchain_path}/usr/lib/clang/" \
-                 "#{xcode_maj_min_version}.0"
+    clang_version = `clang --version`.each_line.first
+    apple_llvm_version = clang_version[/\AApple LLVM version (\d+(?:\.\d+)+)/, 1]
+
+    clang_libs = "#{MacOS::Xcode.toolchain_path}/usr/lib/clang/#{apple_llvm_version}"
     cpp_includes = "#{MacOS::Xcode.toolchain_path}/usr/include/c++"
 
     iwyu_bindir = (iwyu_subdir_path / "bin")

--- a/iwyu.rb
+++ b/iwyu.rb
@@ -38,6 +38,10 @@ class Iwyu < Formula
     iwyu_clang_path.mkpath
     iwyu_clang_path.install_symlink(clang_libs => "#{Iwyu::CLANG_VERSION}.0")
 
+    # Include C++ headers so iwyu can find them (via Clang's relative lookup)
+    cpp_includes = "#{MacOS::Xcode.toolchain_path}/usr/include/c++"
+    include.install_symlink(cpp_includes => "c++")
+
     bin.install("fix_includes.py" => "fix_include")
     bin.install("include-what-you-use")
     bin.install_symlink("include-what-you-use" => "iwyu")


### PR DESCRIPTION
Well, this took longer than expected. But it's fixed now, has better
tests, a matrix build, doesn't squat on gcc include directories, and
removes hardcoded clang versions.

Also, closes #5.